### PR TITLE
MAINT: added dummmy CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,17 @@
+# The only reason this CI exists is that we can require branches to be up
+# to date before merging, which can only be enforced if there is at least
+# one status check enabled.
+
+name: Dummy CI
+
+on: 
+  push:
+
+jobs:
+  dummy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Dummy action
+        run: echo dummy


### PR DESCRIPTION
Added "dummy CI" that will always pass so that we can require branches to be up to date before merging, which can only be enforced if there is at least one status check enabled 😎

Cc: @nathanbaleeta 