### PR TITLE
Add endorsement for Digital Public Goods Alliance

### DIFF
--- a/endorsement.md
+++ b/endorsement.md
@@ -39,6 +39,7 @@ Jon Lloyd | Director of Campaigns at Mozilla Foundation | [Mozilla Foundation](h
 [Liv Marte Nordhaug](https://github.com/livmarte) | Secretariat Co-Lead, Digital Public Goods Alliance | [Digital Public Goods Alliance](https://digitalpublicgoods.net)
 [Cliff Schmidt](https://www.linkedin.com/in/cliffschmidt/) | Executive Director, Amplio Network | [Amplio Network](https://www.amplio.org/)
 [Sudhanshu Shekhar](https://www.linkedin.com/in/sudshekhar02/) | Fellow, iSPIRT |[iSPIRT](https://ispirt.in/)
+[Bodhish Thomas](https://www.linkedin.com/in/bodhish/) | Chief Network Architect, Coronasafe Network | [Coronasafe Network](http://coronasafe.network/)
 [Dau Thuy Ha](https://www.linkedin.com/in/dauthuyha/) | Co-founder, CEO, The Online Management Training Company (OMT), Vietnam | [The Online Management Training Company (OMT), Vietnam](http://omt.vn)
 
 


### PR DESCRIPTION
Excited to support DGP. 

We are building open source tools for governments to manage pandemic/disaster management. 
More detials at: [coronasafe.network](http://coronasafe.network/)