### PR TITLE
Fixed grammar and spelling

### DIFF
--- a/standard-questions.md
+++ b/standard-questions.md
@@ -9,7 +9,7 @@ This document contains the set of questions that are collected in the submission
 * Project Owner: _Please list the primary organization or maintainer of this project i.e. Wikimedia_
 * Project Website URL: _public website_
 * What category best describes this project?: _Select all that apply - Open Source Software, Open Data, Open AI Model, Open Standard, Open Content_
-* For Software: Public Repository URL _Required for open source software - link to public repository_
+* For Software: Public Repository URL _Required for open source software - link to a public repository_
 
 <table>
     <thead>
@@ -37,7 +37,7 @@ This document contains the set of questions that are collected in the submission
             <td valign="top">
                 <ul>
                     <li>Does it use an open license from the OSI list for software?</li>
-                    <li>Does it use a CC license for content (non derivative)?</li>
+                    <li>Does it use a CC license for content (non-derivative)?</li>
                     <li>Does it use an Open Data license from the Open Data Commons list?</li>
                 </ul>
             </td>
@@ -59,13 +59,13 @@ This document contains the set of questions that are collected in the submission
             </td>
         </tr>
         <tr>
-            <td valign="top">4. Does the license of libraries/dependencies undermine the openess of the project?</td>
-            <td valign="top">Does the license of libraries/dependencies undermind the openess of the project?</td>
+            <td valign="top">4. Does the license of libraries/dependencies undermine the openness of the project?</td>
+            <td valign="top">Does the license of libraries/dependencies undermind the openness of the project?</td>
             <td valign="top">
                 <ul>
                     <li>Does this open project have mandatory dependencies (i.e. libraries, hardware) that create more restrictions than the original license?</li>
-                    <li>If yes - are the open source components able to demonstrate independence from the closed component(s) and/or are there functional, open alternatives?</li>
-                    <li>If yes - please describe how the open source components are independent and/or list the open alternatives for the closed component:</li>
+                    <li>If yes - are the open-source components able to demonstrate independence from the closed component(s) and/or are there functional, open alternatives?</li>
+                    <li>If yes - please describe how the open-source components are independent and/or list the open alternatives for the closed component:</li>
                 </ul>
             </td>
         </tr>
@@ -74,7 +74,7 @@ This document contains the set of questions that are collected in the submission
             <td valign="top">Does some documentation exist of the source code, use cases, and/or functional requirements for this project?</td>
             <td valign="top">
                 <ul>
-                    <li>Does some documentation exist of the source code, use cases, and/or functional requirements.<br>For software projects, this should be present as technical documentation that would allow a technical person unfamiliar with the project to launch and run the software. For data projects, this should be present as documentation that describes all the fields in the set, and provides context on how the data was collected and how it should be interpreted. For content, this should indicate any relevant compatible apps, software, hardware required to access the content and any instructions about how to use it.</li>
+                    <li>Does some documentation exist of the source code, use cases, and/or functional requirements?<br>For software projects, this should be present as technical documentation that would allow a technical person unfamiliar with the project to launch and run the software. For data projects, this should be present as documentation that describes all the fields in the set and provides context on how the data was collected and how it should be interpreted. For content, this should indicate any relevant compatible apps, software, hardware required to access the content, and any instructions about how to use it.</li>
                     <li>If yes - please link to the relevant documentation:</li>
                 </ul>
             </td>
@@ -101,7 +101,7 @@ This document contains the set of questions that are collected in the submission
             <td valign="top">
                 <ul>
                     <li>Has this project taken steps to ensure adherence with relevant privacy, domestic, and international laws? For example, the General Data Protection Regulation (GDPR) in the European Union or the Supplementary Act A/SA.1/01/10 on Personal Data Protection for the Economic Community of West African States (ECOWAS) (yes/no)</li>
-                    <li>If yes, please list some of relevant laws that the project complies with:</li>
+                    <li>If yes, please list some of the relevant laws that the project complies with:</li>
                     <li>If yes, please describe the steps this project has taken to ensure adherence (include links to terms of service, privacy policy, or other relevant documentation):</li>
                 </ul>
             </td>
@@ -112,7 +112,7 @@ This document contains the set of questions that are collected in the submission
             <td valign="top">
                 <ul>
                     <li>Does this project support standards?</li>
-                    <li>Which standards does this project support (please list)</li>
+                    <li>Which standards does this project support? (please list)</li>
                     <li>Can you point to evidence of your support? (i.e. please link to your validator, open test suite, etc.)</li>
                 </ul>
             </td>
@@ -122,16 +122,16 @@ This document contains the set of questions that are collected in the submission
             <td valign="top">
                 <ul>
                     <li>Was this project built and developed according to or in adherence with any design, technical and/or sector best practices or principles? i.e. the Principles for Digital Development?</li>
-                    <li>Which principles and best practices does this project support (please list)</li>
+                    <li>Which principles and best practices does this project support? (please list)</li>
                 </ul>
             </td>
         </tr>
         <tr>
             <td rowspan="4" valign="top">9. Does the project do no harm? </td>
-            <td valign="top">Has this project taken steps to anticipate, prevent and do no harm? </td>
+            <td valign="top">Has this project taken steps to anticipate, prevent, and do no harm? </td>
             <td valign="top">
                 <ul>
-                    <li>On the whole, does this project take steps to ensure that it anticipates, prevents and does no harm?</li>
+                    <li>On the whole, does this project take steps to ensure that it anticipates, prevents, and does no harm?</li>
                     <li>Please describe any additional risks and mitigation steps that this project uses to prevent harm.</li>
                 </ul>
             </td>
@@ -144,7 +144,7 @@ This document contains the set of questions that are collected in the submission
                     <li>If yes - please list the types of data collected and/or stored by the project:</li>
                     <li>If yes - does this project share this data with third parties?</li>
                     <li>Please describe the circumstances with which this project shares data with third parties. Please add links as relevant.</li>
-                    <li>If yes - does the project ensure the privacy and security of this data and has it taken steps to prevent adverse impacts resulting from its collection, storage and distribution.</li>
+                    <li>If yes - does the project ensure the privacy and security of this data and has it taken steps to prevent adverse impacts resulting from its collection, storage, and distribution.</li>
                     <li>If yes - please describe the steps, and include a link to the privacy policy and/or terms of service:</li>
                 </ul>
             </td>
@@ -154,11 +154,11 @@ This document contains the set of questions that are collected in the submission
             <td valign="top">
                 <ul>
                     <li>Does this project collect, store or distribute content?</li>
-                    <li>If yes - what kinds of content does this project, collect, store or distribute? (i.e. childrens books)</li>
-                    <li>If yes - does this project have policies that describe what is considered innappropriate content? (i.e. child sexual abuse materials)</li>
+                    <li>If yes - what kinds of content does this project, collect, store or distribute? (i.e. children's books)</li>
+                    <li>If yes - does this project have policies that describe what is considered inappropriate content? (i.e. child sexual abuse materials)</li>
                     <li>If yes - please link to the relevant policy/guidelines/documentation.</li>
-                    <li>If yes - does this project have mechanisms for detecting and moderating innappropriate/illegal content?</li>
-                    <li>If yes - please describe the mechanism for detecting, reporting and removing innapropriate/illegal content (Please include the average response time for assessment and/or action. Link to any policies or descriptions of how inappropriate content is handled):</li>
+                    <li>If yes - does this project have mechanisms for detecting and moderating inappropriate/illegal content?</li>
+                    <li>If yes - please describe the mechanism for detecting, reporting, and removing inapropriate/illegal content (Please include the average response time for assessment and/or action. Link to any policies or descriptions of how inappropriate content is handled):</li>
                 </ul>
             </td>
         </tr>


### PR DESCRIPTION
1. Fixed spelling of "inappropriate". It was incorrectly spelled as "innappropriate"
2. Added articles - "a", "an", and "the" wherever required 
3. Corrected hyphenation wherever necessary. For example, "open-source" instead of "open source"
4. Corrected spelling of "Openness". It was"Openess"
5. Added "?" wherever a question was implied without using a question mark.
6. Removed comma "," wherever it wasn't needed, and added it wherever it was required.
7. Corrected "Children's books"