### PR TITLE
Updating the changelog for 3.0 IGO variant change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,19 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
 
-### Added
+## [1.1.5] 2022-09-20
+- Added list of IGO 3.0 licenses ([#111](https://github.com/DPGAlliance/publicgoods-candidates/blob/main/help-center/licenses.md))
 
-- Add support for OpenStand ([#38](https://github.com/DPGAlliance/DPG-Standard/pull/38))
-- Add mention of 'content to Indicator 6  ([#50](https://github.com/DPGAlliance/DPG-Standard/pull/50), [#100](https://github.com/DPGAlliance/DPG-Standard/pull/100))
-
-### Changed
-
-- Clarified language on DPGA's relationship to other organizations in the space  ([#40](https://github.com/DPGAlliance/DPG-Standard/pull/40))
-- Grammatical edits to governance.md ([#46](https://github.com/DPGAlliance/DPG-Standard/pull/46))
-- Grammatical edits to standards.md ([#45](https://github.com/DPGAlliance/DPG-Standard/pull/45))
-- Grammatical edits to README.md ([#47](https://github.com/DPGAlliance/DPG-Standard/pull/47))
 
 ## [1.1.4] 2021-01-29
 
@@ -108,3 +99,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.0.2]: https://github.com/DPGAlliance/DPG-Standard/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/DPGAlliance/DPG-Standard/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/DPGAlliance/DPG-Standard/releases/tag/v1.0.0
+
+
+
+## Unreleased
+
+### Added
+
+- Add support for OpenStand ([#38](https://github.com/DPGAlliance/DPG-Standard/pull/38))
+- Add mention of 'content to Indicator 6  ([#50](https://github.com/DPGAlliance/DPG-Standard/pull/50), [#100](https://github.com/DPGAlliance/DPG-Standard/pull/100))
+
+### Changed
+
+- Clarified language on DPGA's relationship to other organizations in the space  ([#40](https://github.com/DPGAlliance/DPG-Standard/pull/40))
+- Grammatical edits to governance.md ([#46](https://github.com/DPGAlliance/DPG-Standard/pull/46))
+- Grammatical edits to standards.md ([#45](https://github.com/DPGAlliance/DPG-Standard/pull/45))
+- Grammatical edits to README.md ([#47](https://github.com/DPGAlliance/DPG-Standard/pull/47))


### PR DESCRIPTION
Fixes # .

## Changes proposed in this pull request:
- 
-
-

## Propagation of Changes

Identify where of the following the proposed changes need to be propagated, and include the relevant pull request where appropriate:

- [ ] The DPGA website contains https://digitalpublicgoods.net/standard/ which needs to be updated manually matching the contents of [standard.md](https://github.com/DPGAlliance/DPG-Standard/blob/master/standard.md).
- [ ] The DPGA website also contains the [submission guide](https://digitalpublicgoods.net/submission-guide/) which needs to be updated manually.
- [ ] The [unicef/publicgoods-candidates](https://github.com/unicef/publicgoods-candidates) repository needs the following to be updated:
    - [ ] the [nominee-schema.json](https://github.com/unicef/publicgoods-candidates/blob/master/nominee-schema.json)
    - [ ] the [screening-schema.json](https://github.com/unicef/publicgoods-candidates/blob/master/screening-schema.json)
    - [ ] propagate any changes to all encoded nominees and digital public goods.
    - Link to the corresponding pull request: unicef/publicgoods-candidates#
- [ ] The [Submission Form](https://digitalpublicgoods.net/submission) through the [unicef/publicgoods-submission](https://github.com/unicef/publicgoods-submission) repository, and its corresponding [schema.js](https://github.com/lacabra/submission-digitalpublicgoods/blob/master/schemas/schema.js)
    - Link to the corresponding pull request:
- [ ] The [Eligibility Form](https://digitalpublicgoods.net/eligibility/) through the [unicef/publicgoods-scripts](https://github.com/unicef/publicgoods-submission) repository, by editing [quizQuestions.js](https://github.com/unicef/publicgoods-scripts/blob/master/packages/eligibility/src/api/quizQuestions.js)
    - Link to the corresponding pull request:
