### PR TITLE
Update approved open licenses link

### DIFF
--- a/standard-questions.md
+++ b/standard-questions.md
@@ -43,7 +43,7 @@ This document contains the set of questions that are collected in the submission
             </td>
             <td valign="top">
                 <ul>
-                    <li>DPGs must use an open license. Please identify which of these <a href="https://github.com/unicef/publicgoods-candidates/blob/master/docs/licenses.md" target="_blank">approved open licenses</a> this project uses: </li>
+                    <li>DPGs must use an open license. Please identify which of these <a href="https://github.com/DPGAlliance/publicgoods-candidates/blob/main/help-center/licenses.md" target="_blank">approved open licenses</a> this project uses: </li>
                      <li>Please link to where the license is indicated for this project:</li>
                 </ul>
             </td>


### PR DESCRIPTION
Fixes: Link to approved open licenses was not valid anymore due to changes in the directory.

## Changes proposed in this pull request:
- Update link to the correct file location.

## Propagation of Changes

Identify where of the following the proposed changes need to be propagated, and include the relevant pull request where appropriate:

- [x] The DPGA website contains https://digitalpublicgoods.net/standard/ which needs to be updated manually matching the contents of [standard.md](https://github.com/DPGAlliance/DPG-Standard/blob/master/standard.md).
- [ ] The DPGA website also contains the [submission guide](https://digitalpublicgoods.net/submission-guide/) which needs to be updated manually.
- [ ] The [unicef/publicgoods-candidates](https://github.com/unicef/publicgoods-candidates) repository needs the following to be updated:
    - [ ] the [nominee-schema.json](https://github.com/unicef/publicgoods-candidates/blob/master/nominee-schema.json)
    - [ ] the [screening-schema.json](https://github.com/unicef/publicgoods-candidates/blob/master/screening-schema.json)
    - [ ] propagate any changes to all encoded nominees and digital public goods.
    - Link to the corresponding pull request: unicef/publicgoods-candidates#
- [ ] The [Submission Form](https://digitalpublicgoods.net/submission) through the [unicef/publicgoods-submission](https://github.com/unicef/publicgoods-submission) repository, and its corresponding [schema.js](https://github.com/lacabra/submission-digitalpublicgoods/blob/master/schemas/schema.js)
    - Link to the corresponding pull request:
- [x] The [Eligibility Form](https://digitalpublicgoods.net/eligibility/) through the [unicef/publicgoods-scripts](https://github.com/unicef/publicgoods-submission) repository, by editing [quizQuestions.js](https://github.com/unicef/publicgoods-scripts/blob/master/packages/eligibility/src/api/quizQuestions.js)
    - Link to the corresponding pull request: https://github.com/DPGAlliance/publicgoods-scripts/pull/136
