### PR TITLE
Replace reference to ISG with Board

### DIFF
--- a/governance.md
+++ b/governance.md
@@ -76,12 +76,12 @@ are monthly meetings to catch and address any outstanding issues.
 * [![](https://img.shields.io/badge/-major_change-FFA500)](https://github.com/DPGAlliance/DPG-Standard/labels/major%20change). The moderator will first assign it
 to a member of the DPGA for further investigation over a period of up to two weeks. That person will report and comment on the issue, documenting and exploring
 the implications of accepting or rejecting that change, and will open another period of up to two weeks for additional input from the community. We will inform
-the members of the DPGA's Internal Strategy Group (ISG) giving them an equal opportunity to comment. Reviewing these changes will happen quarterly. Consensus from the 2 co-leads and 2 technical leads 
+the members of the [DPGA's Governance Board](https://digitalpublicgoods.net/governance/) (the Board) giving them an equal opportunity to comment. Reviewing these changes will happen quarterly. Consensus from the 2 co-leads and 2 technical leads 
 (see [Current Roles](#current-roles)) will be required to accept or reject these proposals.
 
 * [![](https://img.shields.io/badge/-fundamental-b60205)](https://github.com/DPGAlliance/DPG-Standard/labels/fundamental). After validating the legitimacy of the 
 proposal, we will open a consultation process with significant communities and stakeholders throughout the ecosystem, including all [endorsers](endorsement.md).
-The findings from this consultation process will be presented to the DPGA's Internal Strategy Group (ISG), who will have a week to veto or ask for more time
+The findings from this consultation process will be presented to the[DPGA's Governance Board](https://digitalpublicgoods.net/governance/) (the Board) , who will have a week to veto or ask for more time
 (where silence is implied consent). Consensus from the 2 co-leads and 2 technical leads (see [Current Roles](#current-roles)) will be required to  
 either accept or reject the proposal. Reviewing these changes will occur twice per year during the first year, and yearly thereafter.
 


### PR DESCRIPTION
Fixes # .

## Changes proposed in this pull request:
- Replace reference to the Interim Strategy Group (ISG) to the Governance Board
-
-

## Propagation of Changes

Identify where of the following the proposed changes need to be propagated, and include the relevant pull request where appropriate:

- [ ] The DPGA website contains https://digitalpublicgoods.net/standard/ which needs to be updated manually matching the contents of [standard.md](https://github.com/DPGAlliance/DPG-Standard/blob/master/standard.md).
- [ ] The DPGA website also contains the [submission guide](https://digitalpublicgoods.net/submission-guide/) which needs to be updated manually.
- [ ] The [unicef/publicgoods-candidates](https://github.com/unicef/publicgoods-candidates) repository needs the following to be updated:
    - [ ] the [nominee-schema.json](https://github.com/unicef/publicgoods-candidates/blob/master/nominee-schema.json)
    - [ ] the [screening-schema.json](https://github.com/unicef/publicgoods-candidates/blob/master/screening-schema.json)
    - [ ] propagate any changes to all encoded nominees and digital public goods.
    - Link to the corresponding pull request: unicef/publicgoods-candidates#
- [ ] The [Submission Form](https://digitalpublicgoods.net/submission) through the [unicef/publicgoods-submission](https://github.com/unicef/publicgoods-submission) repository, and its corresponding [schema.js](https://github.com/lacabra/submission-digitalpublicgoods/blob/master/schemas/schema.js)
    - Link to the corresponding pull request:
- [ ] The [Eligibility Form](https://digitalpublicgoods.net/eligibility/) through the [unicef/publicgoods-scripts](https://github.com/unicef/publicgoods-submission) repository, by editing [quizQuestions.js](https://github.com/unicef/publicgoods-scripts/blob/master/packages/eligibility/src/api/quizQuestions.js)
    - Link to the corresponding pull request:
