### PR TITLE
Update pull_request_template.md

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -12,12 +12,6 @@ Identify where of the following the proposed changes need to be propagated, and 
 
 - [ ] The DPGA website contains https://digitalpublicgoods.net/standard/ which needs to be updated manually matching the contents of [standard.md](https://github.com/DPGAlliance/DPG-Standard/blob/master/standard.md).
 - [ ] The DPGA website also contains the [submission guide](https://digitalpublicgoods.net/submission-guide/) which needs to be updated manually.
-- [ ] The [unicef/publicgoods-candidates](https://github.com/unicef/publicgoods-candidates) repository needs the following to be updated:
-    - [ ] the [nominee-schema.json](https://github.com/unicef/publicgoods-candidates/blob/master/nominee-schema.json)
-    - [ ] the [screening-schema.json](https://github.com/unicef/publicgoods-candidates/blob/master/screening-schema.json)
-    - [ ] propagate any changes to all encoded nominees and digital public goods.
-    - Link to the corresponding pull request: unicef/publicgoods-candidates#
-- [ ] The [Submission Form](https://digitalpublicgoods.net/submission) through the [unicef/publicgoods-submission](https://github.com/unicef/publicgoods-submission) repository, and its corresponding [schema.js](https://github.com/lacabra/submission-digitalpublicgoods/blob/master/schemas/schema.js)
-    - Link to the corresponding pull request:
+- [ ] The DPG application [webapp admin panel](https://app.digitalpublicgoods.net/login) which will be updated manually. 
 - [ ] The [Eligibility Form](https://digitalpublicgoods.net/eligibility/) through the [unicef/publicgoods-scripts](https://github.com/unicef/publicgoods-submission) repository, by editing [quizQuestions.js](https://github.com/unicef/publicgoods-scripts/blob/master/packages/eligibility/src/api/quizQuestions.js)
-    - Link to the corresponding pull request:
+   


### PR DESCRIPTION
Fixes # .

## Changes proposed in this pull request:
- Updating the checklist of the pull request template since we now use the Webapp to process applications and not GitHub. 



## Propagation of Changes

Identify where of the following the proposed changes need to be propagated, and include the relevant pull request where appropriate:

- [ ] The DPGA website contains https://digitalpublicgoods.net/standard/ which needs to be updated manually matching the contents of [standard.md](https://github.com/DPGAlliance/DPG-Standard/blob/master/standard.md).
- [ ] The DPGA website also contains the [submission guide](https://digitalpublicgoods.net/submission-guide/) which needs to be updated manually.
- [ ] The [unicef/publicgoods-candidates](https://github.com/unicef/publicgoods-candidates) repository needs the following to be updated:
    - [ ] the [nominee-schema.json](https://github.com/unicef/publicgoods-candidates/blob/master/nominee-schema.json)
    - [ ] the [screening-schema.json](https://github.com/unicef/publicgoods-candidates/blob/master/screening-schema.json)
    - [ ] propagate any changes to all encoded nominees and digital public goods.
    - Link to the corresponding pull request: unicef/publicgoods-candidates#
- [ ] The [Submission Form](https://digitalpublicgoods.net/submission) through the [unicef/publicgoods-submission](https://github.com/unicef/publicgoods-submission) repository, and its corresponding [schema.js](https://github.com/lacabra/submission-digitalpublicgoods/blob/master/schemas/schema.js)
    - Link to the corresponding pull request:
- [ ] The [Eligibility Form](https://digitalpublicgoods.net/eligibility/) through the [unicef/publicgoods-scripts](https://github.com/unicef/publicgoods-submission) repository, by editing [quizQuestions.js](https://github.com/unicef/publicgoods-scripts/blob/master/packages/eligibility/src/api/quizQuestions.js)
    - Link to the corresponding pull request:
